### PR TITLE
Update code so that the battery information is also updated in the sp…

### DIFF
--- a/core/class/ajaxSystem.class.php
+++ b/core/class/ajaxSystem.class.php
@@ -459,11 +459,26 @@ class ajaxSystem extends eqLogic {
       }
       $this->checkAndUpdateCmd($cmd, $value);
     }
+
+    //Refresh batterie depuis trame de synchronisation / refresh
+    $batteryChargeLevel = '-1';
     if (isset($datas['batteryChargeLevelPercentage'])) {
-      $this->batteryStatus($datas['batteryChargeLevelPercentage']);
+      $batteryChargeLevel = $datas['batteryChargeLevelPercentage'];  
     }
     if (isset($datas['battery']) && isset($datas['battery']['chargeLevelPercentage'])) {
-      $this->batteryStatus($datas['battery']['chargeLevelPercentage']);
+      $batteryChargeLevel = $datas['battery']['chargeLevelPercentage'];
+    }
+
+    //Si niveau de charge numérique disponible, mise à jour de l'information
+    if($batteryChargeLevel != '-1'){
+      //Au niveau de l'équipement
+      $this->batteryStatus($batteryChargeLevel);
+
+      //Au niveau de la commande spécifique si elle existe
+      $batteryCmd = $this->getCmd('info', 'battery::chargeLevelPercentage');
+      if(is_object($batteryCmd)){
+        $this->checkAndUpdateCmd('battery::chargeLevelPercentage', $value);
+      }
     }
   }
 

--- a/core/php/jeeAjaxSystem.php
+++ b/core/php/jeeAjaxSystem.php
@@ -44,7 +44,15 @@ foreach ($datas['data'] as $data) {
     }
     foreach ($data['updates'] as $key => &$value) {
       if ($key == 'batteryCharge') {
+        //Actualisation de la charge de la batterie au niveau de l'équipement jeedom
         $ajaxSystem->batteryStatus($value);
+
+        //Actualisation de la commande batterie si elle existe si l'équipement
+        //Cette commande existe actuellement sur les HUB2, HUB2_4G, et HUB2_PLUS
+        $batteryCmd = $ajaxSystem->getCmd('info', 'battery::chargeLevelPercentage');
+        if(is_object($batteryCmd)){
+              $ajaxSystem->checkAndUpdateCmd('battery::chargeLevelPercentage', $value);
+        }
       }
       if (in_array($data['type'], array('HUB', 'GROUP')) && $key == 'state') {
         if ($value == 0) {


### PR DESCRIPTION
Adapt code to refresh battery commands if present on the equipement.

## Description
The current implementation will only update the general battery status on the equipement, as visible from the equipement tabs from the core.

This adaptation makes it so that if the equipement has a specific Battery command, such as HUB2, HUB2_4G and HUB2_PLUS (for the moment given the current device configurations), that command will also get updated.
This adaptation covers both the synchronisation via a Refresh answer frame, but also the update frames containing the payload 'batteryCharge'.

Disclaimer : this does not cover the battery powered devices such as sensor, door motion, etc.
I will implement that at a later stage.

### Suggested changelog entry
Implementation of the battery charge level refresh from both Sync and Update data frames for HUB2, HUB2 4G and HUB2 PLUS.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes)_
- [X] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.