### PR TITLE
bugfix typo in install.php

### DIFF
--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -30,7 +30,7 @@ function ajaxSystem_update() {
     $cron->remove();
   }
   foreach (eqLogic::byType('ajaxSystem') as $eqLogic) {
-    $cmd = $eqLogic->getCm('action', 'refresh');
+    $cmd = $eqLogic->getCmd('action', 'refresh');
     if (is_object($cmd)) {
       $cmd->remove();
     }


### PR DESCRIPTION
Typo fix in install.php
It was written getCm instead of getCmd.


## Description
Bugfix, see general summary


### Suggested changelog entry
Bugfix for post update install script of the plugin.


## Types of changes
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] [Required for new sniffs] I have added MD documentation for the sniff.