### PR TITLE
Update ajaxSystem.class.php

### DIFF
--- a/core/class/ajaxSystem.class.php
+++ b/core/class/ajaxSystem.class.php
@@ -31,10 +31,10 @@ class ajaxSystem extends eqLogic {
     $return['info']['string']['state'] = array(
       'template' => 'tmplmultistate',
       'test' => array(
-        array('operation' => '#value# == "ARMED"', 'state_light' => '<i class="fas fa-lock"></i>'),
-        array('operation' => '#value# == "DISARMED"', 'state_light' => '<i class="fas fa-lock-open"></i>'),
+        array('operation' => '#value# == "ARMED_NIGHT_MODE_OFF"', 'state_light' => '<i class="fas fa-lock"></i>'),
+        array('operation' => '#value# == "DISARMED_NIGHT_MODE_ON"', 'state_light' => '<i class="fas fa-moon"></i>'),
         array('operation' => '#value# == "DISARMED_NIGHT_MODE_OFF"', 'state_light' => '<i class="fas fa-lock-open"></i>'),
-        array('operation' => '#value# == "NIGHT_MODE"', 'state_light' => '<i class="fas fa-moon"></i>'),
+        array('operation' => '#value# == "ARMED_NIGHT_MODE_ON"', 'state_light' => '<i class="fas fa-lock"></i>'),
         array('operation' => '#value# == "PANIC"', 'state_light' => '<i class="fas fa-exclamation-circle"></i>')
       )
     );


### PR DESCRIPTION
Fixing the variable names for the icons

<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description

I had the plugin on my own system, but it did not show the Icons when the state changed from armed to unarmed or night mode. I tested a bit around with my Ajax system to receive the actual variable names that work. (I tested them on my system and now the icons work again). I put the new variables into the code where it reads the state to put the icon.

Due to the naming changing with the new variables, I organized the icons to work with a priority system, as now night mode and arming status are combined. For this I took the "Arming status" as the most important information and this then is a "lock" symbol independent of the night mode. After this comes the "Night Mode status", if it is active it overwrites the remaining disarm and shows the "moon" symbol. then as last comes the "Disarm status" that has the "open lock" symbol. I would have taken an different moon icon for the "Armed and Night Mode on" mode, but for simplicity I kept it with the ones that were there originally and also to not make it not work again. 

With the new variable names, they will be shown again in the dashboard and the designs.

For the commit please take a look at the file "ajaxSystem.class.php" under the path "/core/class"


### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->

Fixed the variable names for the icons shown in the dashboard/design.

### Related issues/external references

Outdated icon variable names

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have checked there is no other PR open for the same change.
- [X] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [X] I grant the project the right to include and distribute the code under the GNU.
- [X] I have added tests to cover my changes.
- [X] I have verified that the code complies with the projects coding standards.
- [X] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
