### PR TITLE
fix: résoudre la collision des logicalId des groupes en multi-hubs et gérer le retour false de l'API

### DIFF
--- a/core/class/ajaxSystem.class.php
+++ b/core/class/ajaxSystem.class.php
@@ -203,25 +203,40 @@ class ajaxSystem extends eqLogic {
 
       $groups = self::request('/user/{userId}/hubs/' . $hub['hubId'] . '/groups');
       log::add('ajaxSystem', 'debug', json_encode($groups));
-      foreach ($groups as $group) {
-        if($group['groupName'] == ''){
-          continue;
+      if (!is_array($groups)) {
+        log::add('ajaxSystem', 'warning', __('Impossible de récupérer les groupes pour le hub ', __FILE__) . $hub['hubId'] . ' : ' . json_encode($groups));
+      } else {
+        foreach ($groups as $group) {
+          if($group['groupName'] == ''){
+            continue;
+          }
+          $groupLogicalId = $hub['hubId'] . '_' . $group['id'];
+          $eqLogic = eqLogic::byLogicalId($groupLogicalId, 'ajaxSystem');
+          // Migration: check for old-style logicalId without hub prefix
+          if (!is_object($eqLogic)) {
+            $eqLogic = eqLogic::byLogicalId($group['id'], 'ajaxSystem');
+            if (is_object($eqLogic) && $eqLogic->getConfiguration('type') == 'group') {
+              log::add('ajaxSystem', 'info', __('Migration du groupe ', __FILE__) . $group['groupName'] . ' vers le nouveau logicalId ' . $groupLogicalId);
+            } else {
+              $eqLogic = null;
+            }
+          }
+          if (!is_object($eqLogic)) {
+            $eqLogic = new ajaxSystem();
+            $eqLogic->setEqType_name('ajaxSystem');
+            $eqLogic->setIsEnable(1);
+            $eqLogic->setName($group['groupName']);
+            $eqLogic->setCategory('security', 1);
+            $eqLogic->setIsVisible(1);
+          }
+          $eqLogic->setConfiguration('hub_id', $hub['hubId']);
+          $eqLogic->setConfiguration('type', 'group');
+          $eqLogic->setConfiguration('device', 'group');
+          $eqLogic->setConfiguration('group_id', $group['id']);
+          $eqLogic->setLogicalId($groupLogicalId);
+          $eqLogic->save();
+          $eqLogic->refreshData($group);
         }
-        $eqLogic = eqLogic::byLogicalId($group['id'], 'ajaxSystem');
-        if (!is_object($eqLogic)) {
-          $eqLogic = new ajaxSystem();
-          $eqLogic->setEqType_name('ajaxSystem');
-          $eqLogic->setIsEnable(1);
-          $eqLogic->setName($group['groupName']);
-          $eqLogic->setCategory('security', 1);
-          $eqLogic->setIsVisible(1);
-        }
-        $eqLogic->setConfiguration('hub_id', $hub['hubId']);
-        $eqLogic->setConfiguration('type', 'group');
-        $eqLogic->setConfiguration('device', 'group');
-        $eqLogic->setLogicalId($group['id']);
-        $eqLogic->save();
-        $eqLogic->refreshData($group);
       }
     }
   }
@@ -294,6 +309,22 @@ class ajaxSystem extends eqLogic {
       }
       if ($this->getConfiguration('type') == 'device') {
         $datas = self::request('/user/{userId}/hubs/' . $this->getConfiguration('hub_id') . '/devices/' . $this->getLogicalId());
+      }
+      if ($this->getConfiguration('type') == 'group') {
+        $groupId = $this->getConfiguration('group_id', $this->getLogicalId());
+        $allGroups = self::request('/user/{userId}/hubs/' . $this->getConfiguration('hub_id') . '/groups');
+        $datas = null;
+        if (is_array($allGroups)) {
+          foreach ($allGroups as $g) {
+            if (isset($g['id']) && $g['id'] == $groupId) {
+              $datas = $g;
+              break;
+            }
+          }
+        }
+        if ($datas === null) {
+          return;
+        }
       }
     }else{
       $datas = $_data;
@@ -403,12 +434,13 @@ class ajaxSystemCmd extends cmd {
       log::add('ajaxSystem','debug','Command send to ajax : '.json_encode($command));
       ajaxSystem::request('/user/{userId}/hubs/' . $eqLogic->getConfiguration('hub_id') . '/devices/' . $eqLogic->getLogicalId() . '/command', $command, 'POST');
     } else if ($eqLogic->getConfiguration('type') == 'group') {
+      $groupId = $eqLogic->getConfiguration('group_id', $eqLogic->getLogicalId());
       if ($this->getLogicalId() == 'ARM') {
-        ajaxSystem::request('/user/{userId}/hubs/' . $eqLogic->getConfiguration('hub_id') . '/groups/' . $eqLogic->getLogicalId()  . '/commands/arming', array('command' => 'ARM', 'ignoreProblems' => true), 'PUT');
+        ajaxSystem::request('/user/{userId}/hubs/' . $eqLogic->getConfiguration('hub_id') . '/groups/' . $groupId  . '/commands/arming', array('command' => 'ARM', 'ignoreProblems' => true), 'PUT');
       } else if ($this->getLogicalId() == 'DISARM') {
-        ajaxSystem::request('/user/{userId}/hubs/' . $eqLogic->getConfiguration('hub_id') . '/groups/' . $eqLogic->getLogicalId() . '/commands/arming', array('command' => 'DISARM', 'ignoreProblems' => true), 'PUT');
+        ajaxSystem::request('/user/{userId}/hubs/' . $eqLogic->getConfiguration('hub_id') . '/groups/' . $groupId . '/commands/arming', array('command' => 'DISARM', 'ignoreProblems' => true), 'PUT');
       } else if ($this->getLogicalId() == 'NIGHT_MODE') {
-        ajaxSystem::request('/user/{userId}/hubs/' . $eqLogic->getConfiguration('hub_id') . '/groups/' . $eqLogic->getLogicalId() . '/commands/arming', array('command' => 'NIGHT_MODE_ON', 'ignoreProblems' => true), 'PUT');
+        ajaxSystem::request('/user/{userId}/hubs/' . $eqLogic->getConfiguration('hub_id') . '/groups/' . $groupId . '/commands/arming', array('command' => 'NIGHT_MODE_ON', 'ignoreProblems' => true), 'PUT');
       }
     }
   }


### PR DESCRIPTION
Résout #43 
Changements
1. Préfixage du logicalId des groupes (Bug 1)
Le logicalId passe de {groupId} à {hubId}_{groupId} pour garantir l'unicité entre hubs.
L'ID Ajax brut est stocké dans configuration.group_id pour les appels API.
2. Migration automatique
Si un groupe existe avec l'ancien format de logicalId, il est automatiquement migré vers le nouveau format lors de la prochaine synchronisation. Un log info est émis pour tracer la migration.
3. Validation du retour API (Bug 2)
Avant d'itérer sur $groups, le code vérifie que la réponse est bien un tableau avec is_array(). Si ce n'est pas le cas, un log warning est émis au lieu d'un échec silencieux.
4. Support du refresh pour les groupes (Bug 3)
refreshData() gère maintenant le type group en récupérant la liste des groupes du hub et en filtrant par group_id.
5. Mise à jour de execute()
Les commandes de groupe utilisent configuration.group_id au lieu du logicalId pour construire les URLs API, avec fallback sur le logicalId pour la rétrocompatibilité.
Impact

Utilisateurs mono-hub : aucun changement fonctionnel visible, juste un logicalId plus long
Utilisateurs multi-hubs : les groupes seront enfin correctement distincts après re-synchronisation
Groupes existants : migrés automatiquement, aucune intervention manuelle requise
Rétrocompatibilité : le fallback sur logicalId dans execute() assure le fonctionnement même sans re-sync immédiate